### PR TITLE
[Compose] fixes ANDAND & OROR case for visitWhen.

### DIFF
--- a/compose/compiler/compiler-hosted/integration-tests/src/test/java/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
+++ b/compose/compiler/compiler-hosted/integration-tests/src/test/java/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
@@ -45,6 +45,48 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
     )
 
     @Test
+    fun testAND(): Unit = controlFlow(
+        """
+            @NonRestartableComposable
+            @Composable
+            fun Example() {
+                B() && B()
+            }
+        """,
+        """
+            @NonRestartableComposable
+            @Composable
+            fun Example(%composer: Composer?, %changed: Int) {
+              %composer.startReplaceableGroup(<>, "C(Example)<B()>,<B()>:Test.kt")
+              val tmp0_group = B(%composer, 0) && B(%composer, 0)
+              tmp0_group
+              %composer.endReplaceableGroup()
+            }
+        """
+    )
+
+    @Test
+    fun testOR(): Unit = controlFlow(
+        """
+            @NonRestartableComposable
+            @Composable
+            fun Example() {
+                B() || B()
+            }
+        """,
+        """
+            @NonRestartableComposable
+            @Composable
+            fun Example(%composer: Composer?, %changed: Int) {
+              %composer.startReplaceableGroup(<>, "C(Example)<B()>,<B()>:Test.kt")
+              val tmp0_group = B(%composer, 0) || B(%composer, 0)
+              tmp0_group
+              %composer.endReplaceableGroup()
+            }
+        """
+    )
+
+    @Test
     fun testIfWithCallsInBranch(): Unit = controlFlow(
         """
             @NonRestartableComposable @Composable
@@ -61,14 +103,10 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<A()>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A()>")
                 A(%composer, 0)
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -492,20 +530,8 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int?, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
-              val tmp0_safe_receiver = x
-              when {
-                tmp0_safe_receiver == null -> {
-                  %composer.startReplaceableGroup(<>)
-                  %composer.endReplaceableGroup()
-                  null
-                }
-                else -> {
-                  %composer.startReplaceableGroup(<>, "<A()>")
-                  tmp0_safe_receiver.A(%composer, 0b1110 and %changed)
-                  %composer.endReplaceableGroup()
-                }
-              }
+              %composer.startReplaceableGroup(<>, "C(Example)<A()>:Test.kt")
+              x?.A(%composer, 0b1110 and %changed)
               %composer.endReplaceableGroup()
             }
         """
@@ -525,21 +551,17 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int?, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<R()>:Test.kt")
               val y = val tmp0_elvis_lhs = x
-              when {
+              val tmp0_group = when {
                 tmp0_elvis_lhs == null -> {
-                  %composer.startReplaceableGroup(<>, "<R()>")
-                  val tmp0_group = R(%composer, 0)
-                  %composer.endReplaceableGroup()
-                  tmp0_group
+                  R(%composer, 0)
                 }
                 else -> {
-                  %composer.startReplaceableGroup(<>)
-                  %composer.endReplaceableGroup()
                   tmp0_elvis_lhs
                 }
               }
+              tmp0_group
               %composer.endReplaceableGroup()
             }
         """
@@ -820,16 +842,12 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<A()>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A()>")
                 A(%composer, 0)
-                %composer.endReplaceableGroup()
                 %composer.endReplaceableGroup()
                 return
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               print("hello")
               %composer.endReplaceableGroup()
@@ -880,17 +898,13 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int): Int {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<A()>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A()>")
                 A(%composer, 0)
                 val tmp1_return = 1
                 %composer.endReplaceableGroup()
-                %composer.endReplaceableGroup()
                 return tmp1_return
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               val tmp0 = 2
               %composer.endReplaceableGroup()
@@ -952,7 +966,7 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             }
         """
     )
-
+    //Todo: discuss this
     @Test
     fun testEarlyReturnCallValue(): Unit = controlFlow(
         """
@@ -969,16 +983,15 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int): Int {
               %composer.startReplaceableGroup(<>, "C(Example)<R()>:Test.kt")
+              %composer.startReplaceableGroup(<>, "<R()>")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<R()>")
                 val tmp1_return = R(%composer, 0)
                 %composer.endReplaceableGroup()
                 %composer.endReplaceableGroup()
                 return tmp1_return
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
+              %composer.endReplaceableGroup()
               val tmp0 = R(%composer, 0)
               %composer.endReplaceableGroup()
               return tmp0
@@ -1501,7 +1514,7 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             }
         """
     )
-
+    //Todo: discuss
     @Test
     fun testWhileInsideIfAndCallAfter(): Unit = controlFlow(
         """
@@ -1519,19 +1532,13 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)*<A()>,<A()>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A()>")
-                %composer.startReplaceableGroup(<>, "*<A()>")
                 while (x > 0) {
                   A(%composer, 0)
                 }
-                %composer.endReplaceableGroup()
                 A(%composer, 0)
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -1555,17 +1562,13 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<A()>,*<A()>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A()>,*<A()>")
                 A(%composer, 0)
                 while (x > 0) {
                   A(%composer, 0)
                 }
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -1588,16 +1591,12 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)*<A()>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "*<A()>")
                 while (x > 0) {
                   A(%composer, 0)
                 }
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -1844,14 +1843,10 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
               %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "")
                 %composer.startMovableGroup(<>, x, "<A()>")
                 A(%composer, 0)
                 %composer.endMovableGroup()
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -1875,17 +1870,13 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<A(b)>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A(b)>")
                 %composer.startMovableGroup(<>, x, "<A(a)>")
                 A(a, %composer, 0)
                 %composer.endMovableGroup()
                 A(b, %composer, 0)
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -1909,17 +1900,13 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @NonRestartableComposable
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int) {
-              %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
+              %composer.startReplaceableGroup(<>, "C(Example)<A(a)>:Test.kt")
               if (x > 0) {
-                %composer.startReplaceableGroup(<>, "<A(a)>")
                 A(a, %composer, 0)
                 %composer.startMovableGroup(<>, x, "<A(b)>")
                 A(b, %composer, 0)
                 %composer.endMovableGroup()
-                %composer.endReplaceableGroup()
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
               }
               %composer.endReplaceableGroup()
             }
@@ -2000,7 +1987,7 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             }
         """
     )
-
+    //Todo: discuss
     @Test
     fun testDynamicWrappingGroupWithReturnValue(): Unit = controlFlow(
         """
@@ -2018,9 +2005,8 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             @Composable
             fun Example(x: Int, %composer: Composer?, %changed: Int): Int {
               %composer.startReplaceableGroup(<>, "C(Example):Test.kt")
-              val tmp0 = if (x > 0) {
-                %composer.startReplaceableGroup(<>, "")
-                val tmp4_group =
+              val tmp0 = 
+              val tmp4_group = if (x > 0) {
                 val tmp3_group = if (%composer.startReplaceableGroup(<>, "<B()>")
                 val tmp1_group = B(%composer, 0)
                 %composer.endReplaceableGroup()
@@ -2029,13 +2015,10 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
                 %composer.endReplaceableGroup()
                 tmp2_group) 2 else 3
                 tmp3_group
-                %composer.endReplaceableGroup()
-                tmp4_group
               } else {
-                %composer.startReplaceableGroup(<>)
-                %composer.endReplaceableGroup()
                 4
               }
+              tmp4_group
               %composer.endReplaceableGroup()
               return tmp0
             }
@@ -2161,28 +2144,22 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
               }
               if (%dirty and 0b1011 xor 0b0010 !== 0 || !%composer.skipping) {
                 val tmp0_safe_receiver = x
+                %composer.startReplaceableGroup(<>, "<A(a)>,*<A(b)>")
                 when {
                   tmp0_safe_receiver == null -> {
-                    %composer.startReplaceableGroup(<>)
-                    %composer.endReplaceableGroup()
                     null
                   }
                   else -> {
-                    %composer.startReplaceableGroup(<>, "*<A(b)>")
                     tmp0_safe_receiver.let { it: Int ->
                       if (it > 0) {
-                        %composer.startReplaceableGroup(<>, "<A(a)>")
                         A(a, %composer, 0)
-                        %composer.endReplaceableGroup()
                       } else {
-                        %composer.startReplaceableGroup(<>)
-                        %composer.endReplaceableGroup()
                       }
                       A(b, %composer, 0)
                     }
-                    %composer.endReplaceableGroup()
                   }
                 }
+                %composer.endReplaceableGroup()
                 A(c, %composer, 0)
               } else {
                 %composer.skipToGroupEnd()

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -3070,8 +3070,8 @@ class ComposableFunctionBodyTransformer(
         val endBlock = mutableStatementContainer()
         encounteredReturn(expression.returnTargetSymbol) { endBlock.statements.add(it) }
         return if (expression.value.type
-            .also { if (it is IrSimpleType) it.classifier }
-            .isUnitOrNullableUnit()
+                .also { if (it is IrSimpleType) it.classifier }
+                .isUnitOrNullableUnit()
         ) {
             expression.wrap(listOf(endBlock))
         } else {
@@ -3145,6 +3145,7 @@ class ComposableFunctionBodyTransformer(
         var needsWrappingGroup = false
         var someResultsHaveCalls = false
         var hasElseBranch = false
+        var multipleResultsHaveCalls = false
 
         val transformed = IrWhenImpl(
             expression.startOffset,
@@ -3163,6 +3164,9 @@ class ComposableFunctionBodyTransformer(
                     condScopes.add(Scope.BranchScope())
                     resultScopes.add(resultScope)
 
+                    multipleResultsHaveCalls =
+                        multipleResultsHaveCalls || (someResultsHaveCalls &&
+                            resultScope.hasComposableCalls)
                     someResultsHaveCalls = someResultsHaveCalls || resultScope.hasComposableCalls
                     transformed.branches.add(
                         IrElseBranchImpl(
@@ -3187,6 +3191,9 @@ class ComposableFunctionBodyTransformer(
                     // it doesn't necessitate a group
                     needsWrappingGroup =
                         needsWrappingGroup || (index != 0 && condScope.hasComposableCalls)
+                    multipleResultsHaveCalls =
+                        multipleResultsHaveCalls || (someResultsHaveCalls &&
+                            resultScope.hasComposableCalls)
                     someResultsHaveCalls = someResultsHaveCalls || resultScope.hasComposableCalls
                     transformed.branches.add(
                         IrBranchImpl(
@@ -3241,16 +3248,18 @@ class ComposableFunctionBodyTransformer(
             if (
                 // if no wrapping group but some results have calls, we have to have every result
                 // be a group so that we have a consistent number of groups during execution
-                (someResultsHaveCalls && !needsWrappingGroup) ||
+                (multipleResultsHaveCalls && !needsWrappingGroup) ||
                 // if we are wrapping the if with a group, then we only need to add a group when
                 // the block has composable calls
                 (needsWrappingGroup && resultScope.hasComposableCalls)
             ) {
                 it.result = it.result.asReplaceableGroup(resultScope)
             }
-        }
 
-        return if (needsWrappingGroup) {
+        }
+        return if (needsWrappingGroup ||
+            (someResultsHaveCalls && !multipleResultsHaveCalls)
+        ) {
             transformed.asCoalescableGroup(whenScope)
         } else {
             transformed
@@ -3441,7 +3450,7 @@ class ComposableFunctionBodyTransformer(
                         super.calculateSourceInfo(sourceInformationEnabled)
                     } else {
                         "${callInformation()}${parameterInformation()}${
-                        super.calculateSourceInfo(sourceInformationEnabled) ?: ""
+                            super.calculateSourceInfo(sourceInformationEnabled) ?: ""
                         }:${sourceFileInformation()}"
                     }
                 } else {
@@ -3597,7 +3606,7 @@ class ComposableFunctionBodyTransformer(
                         val lineNumber = fileEntry?.getLineNumber(it.element.startOffset) ?: ""
                         val offset = if (it.element.startOffset < it.element.endOffset) {
                             "@${it.element.startOffset}L${
-                            it.element.endOffset - it.element.startOffset
+                                it.element.endOffset - it.element.startOffset
                             }"
                         } else "@${it.element.startOffset}"
                         if (it.repeatable && !markedRepeatable) {
@@ -3647,12 +3656,14 @@ class ComposableFunctionBodyTransformer(
             private var shouldRealizeCoalescableChild = false
             private var coalescableChild: BlockScope? = null
         }
+
         class ClassScope(name: Name) : Scope("class ${name.asString()}")
         class PropertyScope(name: Name) : Scope("val ${name.asString()}")
         class FieldScope(name: Name) : Scope("field ${name.asString()}")
         class FileScope(val declaration: IrFile) : Scope("file ${declaration.name}") {
             override val fileScope: FileScope? get() = this
         }
+
         class LoopScope(val loop: IrLoop) : BlockScope("loop") {
             private val jumpEndLocations = mutableListOf<(IrExpression) -> Unit>()
             var needsGroupPerIteration = false
@@ -3690,6 +3701,7 @@ class ComposableFunctionBodyTransformer(
                 }
             }
         }
+
         class WhenScope : BlockScope("when")
         class BranchScope : BlockScope("branch")
         class CaptureScope : BlockScope("capture") {
@@ -3706,6 +3718,7 @@ class ComposableFunctionBodyTransformer(
                         get() = true
                 }
         }
+
         class ParametersScope : BlockScope("parameters")
         class ComposableLambdaScope : BlockScope("composableLambda") {
             override fun calculateHasSourceInformation(sourceInformationEnabled: Boolean): Boolean {
@@ -3715,7 +3728,7 @@ class ComposableFunctionBodyTransformer(
             override fun calculateSourceInfo(sourceInformationEnabled: Boolean): String? =
                 if (sourceInformationEnabled) {
                     "C${
-                    super.calculateSourceInfo(sourceInformationEnabled) ?: ""
+                        super.calculateSourceInfo(sourceInformationEnabled) ?: ""
                     }:${functionScope?.sourceFileInformation() ?: ""}"
                 } else {
                     null
@@ -3984,10 +3997,13 @@ private fun IrType.isClassType(fqName: FqNameUnsafe, hasQuestionMark: Boolean? =
     if (hasQuestionMark != null && this.hasQuestionMark != hasQuestionMark) return false
     return classifier.isClassWithFqName(fqName)
 }
+
 private fun IrType.isNotNullClassType(fqName: FqNameUnsafe) =
     isClassType(fqName, hasQuestionMark = false)
+
 private fun IrType.isNullableClassType(fqName: FqNameUnsafe) =
     isClassType(fqName, hasQuestionMark = true)
+
 fun IrType.isNullableUnit() = isNullableClassType(StandardNames.FqNames.unit)
 fun IrType.isUnitOrNullableUnit() = this.isUnit() || this.isNullableUnit()
 

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/IrSourcePrinter.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/IrSourcePrinter.kt
@@ -783,7 +783,15 @@ private class IrSourcePrinterVisitor(
             }
             IrStatementOrigin.SAFE_CALL -> {
                 val lhs = expression.statements[0] as IrVariable
-                val rhs = expression.statements[1] as IrWhen
+                val rhsStatement = expression.statements[1]
+                val rhs = when (rhsStatement) {
+                    is IrBlock -> {
+                        rhsStatement.statements[1]
+                    }
+                    else -> {
+                        rhsStatement
+                    }
+                } as IrWhen
                 val call = rhs.branches.last().result as? IrCall
                 if (call == null) {
                     expression.statements.printJoin("\n")


### PR DESCRIPTION
## Proposed Changes

When the following conditions are met for a when block 
  - There are composable calls in exactly one of the branch result.
  - Only the first branch’s condition may have a composable call and no other branch has composable calls. 
  
Instead of generating a replaceable group for each branch’s result, we will just generate a single group around the whole expression

## Testing

Test: Added ANDAND & OROR test in ControlFlowTransformTests.kt and updated some of the previous tests.

## Issues Fixed

Fixes: [https://issuetracker.google.com/178702177](https://issuetracker.google.com/178702177)
